### PR TITLE
Free struct addrinfo after use

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1544,12 +1544,15 @@ struct sockaddr *EventMachine_t::name2address (const char *server, int port, int
 			case AF_INET:
 				memcpy(&in4, ai->ai_addr, ai->ai_addrlen);
 				in4.sin_port = htons(port);
-				return (struct sockaddr*)&in4;
+#ifndef CYGWIN
 			case AF_INET6:
 				memcpy(&in6, ai->ai_addr, ai->ai_addrlen);
 				in6.sin6_port = htons(port);
-				return (struct sockaddr*)&in6;
+#endif
 		}
+
+		freeaddrinfo(ai);
+		return (struct sockaddr*)&in4;
 	}
 
 	return NULL;


### PR DESCRIPTION
Missed this in the initial patch.  Also avoid a compilation error on Cygwin
due to not having IPv6 supported there.
